### PR TITLE
Improve spawner

### DIFF
--- a/include/ChromaBlade.hpp
+++ b/include/ChromaBlade.hpp
@@ -16,7 +16,7 @@
 #include "EventType.hpp"
 
 #define WIDTH 800
-#define HEIGHT 600
+#define HEIGHT 608
 
 class ChromaBlade{
 public:

--- a/include/GameLogic.hpp
+++ b/include/GameLogic.hpp
@@ -38,7 +38,7 @@ public:
 
 private:
     bool checkCollisions(const sf::FloatRect& fr);
-    bool checkDoors(const sf::FloatRect& fr);
+    bool checkDoors(sf::FloatRect fr, int extra);
     void moveChar(const EventInterface& event);
     void attack(const EventInterface& event);
     void spawn(const EventInterface& event);

--- a/include/GameLogic.hpp
+++ b/include/GameLogic.hpp
@@ -37,6 +37,8 @@ public:
     void toggleLevel();
 
 private:
+    bool checkCollisions();
+    bool checkDoors();
     void moveChar(const EventInterface& event);
     void attack(const EventInterface& event);
     void spawn(const EventInterface& event);

--- a/include/GameLogic.hpp
+++ b/include/GameLogic.hpp
@@ -37,8 +37,8 @@ public:
     void toggleLevel();
 
 private:
-    bool checkCollisions();
-    bool checkDoors();
+    bool checkCollisions(const sf::FloatRect& fr);
+    bool checkDoors(const sf::FloatRect& fr);
     void moveChar(const EventInterface& event);
     void attack(const EventInterface& event);
     void spawn(const EventInterface& event);

--- a/include/PlayerView.hpp
+++ b/include/PlayerView.hpp
@@ -11,6 +11,7 @@
 #include "TileMap.hpp"
 #include <vector>
 
+#define TILE_DIM 32
 
 class ChromaBlade; // Forward declaration of class ChromaBlade, so that we can declare a pointer to ChromaBlade in PlayerView
 

--- a/src/GameLogic.cpp
+++ b/src/GameLogic.cpp
@@ -123,48 +123,48 @@ void GameLogic::moveChar(const EventInterface& event) {
     }
     setCharPosition(std::make_tuple(x, y));
     m_view->drawAnimation(dir, moving, noKeyPressed, deltaTime);
-		bool collisionDetected = false;
-		for(int i = 0; i < m_collisionVector.size(); i++){
-			if (m_sprite->getGlobalBounds().intersects(m_collisionVector[i].getGlobalBounds())){
-				std::cout << "COLLISION! \n";
-				collisionDetected = true;
-				break;
-			}
-		}
-		for (int i=0; i<m_rocks.size(); i++) {
-			if (m_sprite->getGlobalBounds().intersects(m_rocks[i]->getGlobalBounds())) {
-				collisionDetected = true;
-				break;
-			}
-		}
-		if(collisionDetected){
-			setCharPosition(std::make_tuple(prevX, prevY));
-			m_sprite->setPosition(prevX, prevY);
-		}
-		bool doorDetected = false;
-		for(int i = 0; i < m_doors.size(); i++){
-			if (m_sprite->getGlobalBounds().intersects(m_doors[i].getGlobalBounds())){
-				doorDetected = true;
-				break;
-			}
-		}
-		if (doorDetected && !m_onDoor) {
-				std::cout << "onDoor\n";
-				m_onDoor = true;
+    bool collisionDetected = false;
+    for(int i = 0; i < m_collisionVector.size(); i++){
+        if (m_sprite->getGlobalBounds().intersects(m_collisionVector[i].getGlobalBounds())){
+            std::cout << "COLLISION! \n";
+            collisionDetected = true;
+            break;
+        }
+    }
+    for (int i=0; i<m_rocks.size(); i++) {
+        if (m_sprite->getGlobalBounds().intersects(m_rocks[i]->getGlobalBounds())) {
+            collisionDetected = true;
+            break;
+        }
+    }
+    if(collisionDetected){
+        setCharPosition(std::make_tuple(prevX, prevY));
+        m_sprite->setPosition(prevX, prevY);
+    }
+    bool doorDetected = false;
+    for(int i = 0; i < m_doors.size(); i++){
+        if (m_sprite->getGlobalBounds().intersects(m_doors[i].getGlobalBounds())){
+            doorDetected = true;
+            break;
+        }
+    }
+    if (doorDetected && !m_onDoor) {
+        std::cout << "onDoor\n";
+        m_onDoor = true;
 
-				DoorEvent *doorEvent = new DoorEvent(GameState::RedLevel, 1, dir);
-				m_game->queueEvent(doorEvent);
-		} else if (!doorDetected && m_onDoor) {
-				std::cout << "not onDoor\n";
-				m_onDoor = false;
-		}
-		if(m_game->inDebugMode()){
-			std::cout <<"Player Position (sprite then logic): \n " ;
-			x = std::get<0>(m_player.getPosition());
-			y = std::get<1>(m_player.getPosition());
-			std::cout << m_sprite->getPosition().x << "," << m_sprite->getPosition().y << "\n";
-			std::cout << x << "," << y << "\n";
-		}
+        DoorEvent *doorEvent = new DoorEvent(GameState::RedLevel, 1, dir);
+        m_game->queueEvent(doorEvent);
+    } else if (!doorDetected && m_onDoor) {
+        std::cout << "not onDoor\n";
+        m_onDoor = false;
+    }
+    if(m_game->inDebugMode()){
+        std::cout <<"Player Position (sprite then logic): \n " ;
+        x = std::get<0>(m_player.getPosition());
+        y = std::get<1>(m_player.getPosition());
+        std::cout << m_sprite->getPosition().x << "," << m_sprite->getPosition().y << "\n";
+        std::cout << x << "," << y << "\n";
+    }
 }
 
 /* Triggered by a DoorEvent. */

--- a/src/GameLogic.cpp
+++ b/src/GameLogic.cpp
@@ -91,6 +91,7 @@ bool GameLogic::checkCollisions(const sf::FloatRect& fr) {
     }
     for (int i=0; i<m_rocks.size(); i++) {
         if (fr.intersects(m_rocks[i]->getGlobalBounds())) {
+            std::cout << "ROCK COLLISION! \n";
             return true;
         }
     }
@@ -226,7 +227,7 @@ void GameLogic::useDoor(const EventInterface& event) {
                 == m_clearedRooms.end()) {
             sf::Vector2f center = m_view->getCameraCenter();
             sf::Vector2f size = m_view->getCameraSize();
-            SpawnEvent *spawnEvent = new SpawnEvent(Actor::Rock, 1, size, center);
+            SpawnEvent *spawnEvent = new SpawnEvent(Actor::Rock, 10, size, center);
             m_game->queueEvent(spawnEvent);
         }
     }
@@ -254,33 +255,28 @@ void GameLogic::spawn(const EventInterface& event) {
     const sf::Vector2f size = spawnEvent->getSize();
     const sf::Vector2f center = spawnEvent->getCenter();
 
-    int x,y,r,i,j;
-    int minX = center.x - size.x / 2 + 48;
-    int minY = center.y - size.y / 2 + 48;
 
-    int numBlocks = 3;
-    int blockSizeX = size.x / numBlocks;
-    int blockSizeY = size.y / numBlocks;
+    int l = center.x - size.x / 2;
+    int t = center.y - size.y / 2;
 
-    int hash[9] = {0};
+    sf::FloatRect tile;
+    int rx, ry, x, y;
 
-    int n=0;
-    while (n < count) {
+    for (int i=0; i<count; i++) {
         do {
-            r = rand() % 9;
-        } while (r == 3 || hash[r]);
+            rx = rand() % (WIDTH  / TILE_DIM);
+            ry = rand() % (HEIGHT / TILE_DIM);
 
-        hash[r]++;
-        i = r % 3;
-        j = r / 3;
+            x = rx * TILE_DIM + l;
+            y = ry * TILE_DIM + t;
 
-        x = rand() % (blockSizeX-144) + i*blockSizeX + minX;
-        y = rand() % (blockSizeY-144) + j*blockSizeY + minY;
-        printf("%d %d %d %d %d\n", r, i, j, x, y);
-        Actor *actor = new Actor(actorType, sf::Vector2f(32,32), sf::Vector2f(x,y));
+            tile.left = x; tile.top = y;
+            tile.width = tile.height = TILE_DIM;
+        } while (checkCollisions(tile) && checkDoors(tile));
+
+        Actor *actor = new Actor(actorType, sf::Vector2f(TILE_DIM,TILE_DIM), 
+                                            sf::Vector2f(x,y));
         m_rocks.push_back(actor);
-
-        n++;
     }
 }
 

--- a/src/GameLogic.cpp
+++ b/src/GameLogic.cpp
@@ -199,27 +199,30 @@ void GameLogic::useDoor(const EventInterface& event) {
 
     if(levelToggled){
     if (dir == Direction::Left) {
-        m_sprite->setPosition(m_sprite->getPosition().x - WIDTH/8,
-                              m_sprite->getPosition().y);
+        m_sprite->setPosition(
+                ((int) m_sprite->getPosition().x / (int) WIDTH) * WIDTH - 2 * TILE_DIM,
+                       m_sprite->getPosition().y);
         m_view->updateCamera(-WIDTH,0);
     }
     else if (dir == Direction::Right){
-        m_sprite->setPosition(m_sprite->getPosition().x + WIDTH/8,
-                              m_sprite->getPosition().y);
+        m_sprite->setPosition(
+                ((int) m_sprite->getPosition().x / (int) WIDTH + 1) * WIDTH + TILE_DIM,
+                       m_sprite->getPosition().y);
         m_view->updateCamera(WIDTH,0);
     }
     else if (dir == Direction::Up){
         m_sprite->setPosition(m_sprite->getPosition().x,
-                              m_sprite->getPosition().y - HEIGHT/8);
+              ((int) m_sprite->getPosition().y / (int) HEIGHT) * HEIGHT - 2 * TILE_DIM);
         m_view->updateCamera(0,-HEIGHT);
 
     }
     else if (dir == Direction::Down){
       m_sprite->setPosition(m_sprite->getPosition().x,
-                            m_sprite->getPosition().y + HEIGHT/8);
+              ((int) m_sprite->getPosition().y / (int) HEIGHT + 1) * HEIGHT + TILE_DIM);
       m_view->updateCamera(0,HEIGHT);
     }
     setCharPosition(std::make_tuple(m_sprite->getPosition().x, m_sprite->getPosition().y));
+    m_onDoor = false;
     }
 
     if (room > 0) {

--- a/src/GameLogic.cpp
+++ b/src/GameLogic.cpp
@@ -205,12 +205,12 @@ void GameLogic::useDoor(const EventInterface& event) {
     else if (dir == Direction::Right){
         m_sprite->setPosition(m_sprite->getPosition().x + WIDTH/8,
                               m_sprite->getPosition().y);
-        m_view->updateCamera(-WIDTH,0);
+        m_view->updateCamera(WIDTH,0);
     }
     else if (dir == Direction::Up){
         m_sprite->setPosition(m_sprite->getPosition().x,
                               m_sprite->getPosition().y - HEIGHT/8);
-        m_view->updateCamera(0, -HEIGHT);
+        m_view->updateCamera(0,-HEIGHT);
 
     }
     else if (dir == Direction::Down){

--- a/src/GameLogic.cpp
+++ b/src/GameLogic.cpp
@@ -82,6 +82,29 @@ void GameLogic::setListener() {
 
 }
 
+bool GameLogic::checkCollisions() {
+    for(int i = 0; i < m_collisionVector.size(); i++){
+        if (m_sprite->getGlobalBounds().intersects(m_collisionVector[i].getGlobalBounds())){
+            std::cout << "COLLISION! \n";
+            return true;
+        }
+    }
+    for (int i=0; i<m_rocks.size(); i++) {
+        if (m_sprite->getGlobalBounds().intersects(m_rocks[i]->getGlobalBounds())) {
+            return true;
+        }
+    }
+    return false;
+}
+
+bool GameLogic::checkDoors() {
+    for(int i = 0; i < m_doors.size(); i++){
+        if (m_sprite->getGlobalBounds().intersects(m_doors[i].getGlobalBounds())){
+            return true;
+        }
+    }
+    return false;
+}
 
 /***************************** Event Triggered Functions ******************************/
 
@@ -123,31 +146,15 @@ void GameLogic::moveChar(const EventInterface& event) {
     }
     setCharPosition(std::make_tuple(x, y));
     m_view->drawAnimation(dir, moving, noKeyPressed, deltaTime);
-    bool collisionDetected = false;
-    for(int i = 0; i < m_collisionVector.size(); i++){
-        if (m_sprite->getGlobalBounds().intersects(m_collisionVector[i].getGlobalBounds())){
-            std::cout << "COLLISION! \n";
-            collisionDetected = true;
-            break;
-        }
-    }
-    for (int i=0; i<m_rocks.size(); i++) {
-        if (m_sprite->getGlobalBounds().intersects(m_rocks[i]->getGlobalBounds())) {
-            collisionDetected = true;
-            break;
-        }
-    }
-    if(collisionDetected){
+
+    /* Check collisions. */
+    if(checkCollisions()){
         setCharPosition(std::make_tuple(prevX, prevY));
         m_sprite->setPosition(prevX, prevY);
     }
-    bool doorDetected = false;
-    for(int i = 0; i < m_doors.size(); i++){
-        if (m_sprite->getGlobalBounds().intersects(m_doors[i].getGlobalBounds())){
-            doorDetected = true;
-            break;
-        }
-    }
+
+    /* Check doors. */
+    bool doorDetected = checkDoors();
     if (doorDetected && !m_onDoor) {
         std::cout << "onDoor\n";
         m_onDoor = true;

--- a/src/GameLogic.cpp
+++ b/src/GameLogic.cpp
@@ -215,7 +215,7 @@ void GameLogic::useDoor(const EventInterface& event) {
                 == m_clearedRooms.end()) {
             sf::Vector2f center = m_view->getCameraCenter();
             sf::Vector2f size = m_view->getCameraSize();
-            SpawnEvent *spawnEvent = new SpawnEvent(Actor::Rock, 4, size, center);
+            SpawnEvent *spawnEvent = new SpawnEvent(Actor::Rock, 1, size, center);
             m_game->queueEvent(spawnEvent);
         }
     }
@@ -266,8 +266,8 @@ void GameLogic::spawn(const EventInterface& event) {
         x = rand() % (blockSizeX-144) + i*blockSizeX + minX;
         y = rand() % (blockSizeY-144) + j*blockSizeY + minY;
         printf("%d %d %d %d %d\n", r, i, j, x, y);
-        Actor *rock = new Actor(Actor::Rock, sf::Vector2f(32,32), sf::Vector2f(x,y));
-        m_rocks.push_back(rock);
+        Actor *actor = new Actor(actorType, sf::Vector2f(32,32), sf::Vector2f(x,y));
+        m_rocks.push_back(actor);
 
         n++;
     }

--- a/src/GameLogic.cpp
+++ b/src/GameLogic.cpp
@@ -191,21 +191,25 @@ void GameLogic::useDoor(const EventInterface& event) {
 
     if(levelToggled){
     if (dir == Direction::Left) {
-        m_sprite->setPosition(m_sprite->getPosition().x - 100, m_sprite->getPosition().y);
-        m_view->updateCamera(-800,0);
+        m_sprite->setPosition(m_sprite->getPosition().x - WIDTH/8,
+                              m_sprite->getPosition().y);
+        m_view->updateCamera(-WIDTH,0);
     }
     else if (dir == Direction::Right){
-        m_sprite->setPosition(m_sprite->getPosition().x + 100, m_sprite->getPosition().y);
-        m_view->updateCamera(800,0);
+        m_sprite->setPosition(m_sprite->getPosition().x + WIDTH/8,
+                              m_sprite->getPosition().y);
+        m_view->updateCamera(-WIDTH,0);
     }
     else if (dir == Direction::Up){
-        m_sprite->setPosition(m_sprite->getPosition().x, m_sprite->getPosition().y - 100);
-        m_view->updateCamera(0, -608);
+        m_sprite->setPosition(m_sprite->getPosition().x,
+                              m_sprite->getPosition().y - HEIGHT/8);
+        m_view->updateCamera(0, -HEIGHT);
 
     }
     else if (dir == Direction::Down){
-      m_sprite->setPosition(m_sprite->getPosition().x, m_sprite->getPosition().y + 100);
-      m_view->updateCamera(0,608);
+      m_sprite->setPosition(m_sprite->getPosition().x,
+                            m_sprite->getPosition().y + HEIGHT/8);
+      m_view->updateCamera(0,HEIGHT);
     }
     setCharPosition(std::make_tuple(m_sprite->getPosition().x, m_sprite->getPosition().y));
     }

--- a/src/GameLogic.cpp
+++ b/src/GameLogic.cpp
@@ -82,24 +82,24 @@ void GameLogic::setListener() {
 
 }
 
-bool GameLogic::checkCollisions() {
+bool GameLogic::checkCollisions(const sf::FloatRect& fr) {
     for(int i = 0; i < m_collisionVector.size(); i++){
-        if (m_sprite->getGlobalBounds().intersects(m_collisionVector[i].getGlobalBounds())){
+        if (fr.intersects(m_collisionVector[i].getGlobalBounds())){
             std::cout << "COLLISION! \n";
             return true;
         }
     }
     for (int i=0; i<m_rocks.size(); i++) {
-        if (m_sprite->getGlobalBounds().intersects(m_rocks[i]->getGlobalBounds())) {
+        if (fr.intersects(m_rocks[i]->getGlobalBounds())) {
             return true;
         }
     }
     return false;
 }
 
-bool GameLogic::checkDoors() {
+bool GameLogic::checkDoors(const sf::FloatRect& fr) {
     for(int i = 0; i < m_doors.size(); i++){
-        if (m_sprite->getGlobalBounds().intersects(m_doors[i].getGlobalBounds())){
+        if (fr.intersects(m_doors[i].getGlobalBounds())){
             return true;
         }
     }
@@ -148,13 +148,13 @@ void GameLogic::moveChar(const EventInterface& event) {
     m_view->drawAnimation(dir, moving, noKeyPressed, deltaTime);
 
     /* Check collisions. */
-    if(checkCollisions()){
+    if(checkCollisions(m_sprite->getGlobalBounds())){
         setCharPosition(std::make_tuple(prevX, prevY));
         m_sprite->setPosition(prevX, prevY);
     }
 
     /* Check doors. */
-    bool doorDetected = checkDoors();
+    bool doorDetected = checkDoors(m_sprite->getGlobalBounds());
     if (doorDetected && !m_onDoor) {
         std::cout << "onDoor\n";
         m_onDoor = true;

--- a/src/GameLogic.cpp
+++ b/src/GameLogic.cpp
@@ -83,12 +83,15 @@ void GameLogic::setListener() {
 }
 
 bool GameLogic::checkCollisions(const sf::FloatRect& fr) {
+    /* Check intersections with mini collision tiles. */
     for(int i = 0; i < m_collisionVector.size(); i++){
         if (fr.intersects(m_collisionVector[i].getGlobalBounds())){
             std::cout << "COLLISION! \n";
             return true;
         }
     }
+    
+    /* Check intersections with rock tiles. */
     for (int i=0; i<m_rocks.size(); i++) {
         if (fr.intersects(m_rocks[i]->getGlobalBounds())) {
             std::cout << "ROCK COLLISION! \n";
@@ -98,9 +101,16 @@ bool GameLogic::checkCollisions(const sf::FloatRect& fr) {
     return false;
 }
 
-bool GameLogic::checkDoors(const sf::FloatRect& fr) {
+bool GameLogic::checkDoors(sf::FloatRect fr, int extra) {
+    /* Increase bounds if necessary. */
+    fr.top -= TILE_DIM * extra;
+    fr.left -= TILE_DIM * extra;
+    fr.width += TILE_DIM * 2 * extra;
+    fr.height += TILE_DIM * 2 * extra;
+
+    /* Check intersections with mini door tiles. */
     for(int i = 0; i < m_doors.size(); i++){
-        if (fr.intersects(m_doors[i].getGlobalBounds())){
+        if (fr.intersects(m_doors[i].getGlobalBounds())) {
             return true;
         }
     }
@@ -155,7 +165,7 @@ void GameLogic::moveChar(const EventInterface& event) {
     }
 
     /* Check doors. */
-    bool doorDetected = checkDoors(m_sprite->getGlobalBounds());
+    bool doorDetected = checkDoors(m_sprite->getGlobalBounds(), 0);
     if (doorDetected && !m_onDoor) {
         std::cout << "onDoor\n";
         m_onDoor = true;
@@ -266,6 +276,7 @@ void GameLogic::spawn(const EventInterface& event) {
     int rx, ry, x, y;
 
     for (int i=0; i<count; i++) {
+        /* while not on wall or near door... */
         do {
             rx = rand() % (WIDTH  / TILE_DIM);
             ry = rand() % (HEIGHT / TILE_DIM);
@@ -275,8 +286,9 @@ void GameLogic::spawn(const EventInterface& event) {
 
             tile.left = x; tile.top = y;
             tile.width = tile.height = TILE_DIM;
-        } while (checkCollisions(tile) && checkDoors(tile));
+        } while (checkCollisions(tile) || checkDoors(tile, 3));
 
+        /* have a valid spawn location. */
         Actor *actor = new Actor(actorType, sf::Vector2f(TILE_DIM,TILE_DIM), 
                                             sf::Vector2f(x,y));
         m_rocks.push_back(actor);

--- a/src/PlayerView.cpp
+++ b/src/PlayerView.cpp
@@ -183,10 +183,10 @@ void PlayerView::draw() {
             break;
         default:
             m_window->draw(m_map);
+            m_window->draw(m_overlay);
             for (int i=0; i<rocks.size(); i++) {
                 rocks[i]->draw(m_window);
             }
-            m_window->draw(m_overlay);
             m_window->draw(m_filter);
             m_window->draw(animatedSprite);
 


### PR DESCRIPTION
Implement tile-based spawner with collision checking and "nearness" spawning, i.e., not spawning near doors and thereby the player.

@tablackwell Please fill in collision entities with the collision tile (e.g. the pool of water in red dungeon) to prevent spawning inside these entities.